### PR TITLE
change link for notebook

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ code span.ot { color: #007020; }
 <h1>Self assembling claim reserving models</h1>
 <p>Recently, Greg Taylor, Hugh Miller and myself completed some work to develop an approach for fitting a claims reserving model using regularised regression, the LASSO in particular. Full details of this work may be found in the accompanying paper available at <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3241906">https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3241906</a>.</p>
 <p>Following some requests, I have put together a tutorial showing how to fit the model we describe to one of the synthetic data sets used in this paper. Click <a href="https://grainnemcguire.github.io/synthetic_data_example.html">here for a self-contained R notebook</a> detailing the steps involved.</p>
-<p>If you want to access the underlying Rnotebook directly, you may access it at <a href="https://grainnemcguire.github.io/synthetic_data_example.Rmd" class="uri">https://grainnemcguire.github.io/synthetic_data_example.Rmd</a>.</p>
+<p>If you want to access the underlying Rnotebook directly, you may access <a href="https://github.com/grainnemcguire/grainnemcguire.github.io/blob/master/synthetic_data_example.Rmd">synthetic_data_example.Rmd</a> directly.</p>
 </div>
 <div id="changelog" class="section level1">
 <h1>Changelog</h1>


### PR DESCRIPTION
If I link via html and not via github then the notebook loses the starting preamble turning the file into an R notebook, ie everything between the --- lines.